### PR TITLE
Take os.sdk setting into account

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 os: osx
 language: generic
 python: 3.6
-osx_image: xcode9.3
+osx_image: xcode12
 env:
    global:
      - CONAN_REFERENCE: "darwin-toolchain/1.0.8"

--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-from conan.packager import ConanMultiPackager
+from cpt.packager import ConanMultiPackager
 
 
 if __name__ == "__main__":

--- a/conanfile.py
+++ b/conanfile.py
@@ -64,7 +64,7 @@ class DarwinToolchainConan(ConanFile):
         common_flags = ["-isysroot%s" % sysroot]
 
         if self.settings.get_safe("os.version"):
-            common_flags.append(tools.apple_deployment_target_flag(self.settings.os, self.settings.os.version, self.settings.os.sdk))
+            common_flags.append(tools.apple_deployment_target_flag(self.settings.os, self.settings.os.version, os_sdk=self.settings.os.sdk))
 
         if not self.settings.os == "Macos" and self.options.bitcode:
             if self.settings.build_type == "Debug":

--- a/conanfile.py
+++ b/conanfile.py
@@ -64,7 +64,7 @@ class DarwinToolchainConan(ConanFile):
         common_flags = ["-isysroot%s" % sysroot]
 
         if self.settings.get_safe("os.version"):
-            common_flags.append(tools.apple_deployment_target_flag(self.settings.os, self.settings.os.version))
+            common_flags.append(tools.apple_deployment_target_flag(self.settings.os, self.settings.os.version, self.settings.os.sdk))
 
         if not self.settings.os == "Macos" and self.options.bitcode:
             if self.settings.build_type == "Debug":


### PR DESCRIPTION
Is there a reason the `os.sdk` setting was not yet passed to `apple_deployment_target_flag`?

I tried to build a simple test project with the following profile, but got an error:

```
[settings]
os=iOS
os_build=Macos
os.sdk=iphonesimulator
os.version=12.0
arch=armv8
arch_build=x86_64
compiler=apple-clang
compiler.cppstd=17
compiler.version=12.0
compiler.libcxx=libc++
build_type=Release
[options]
[build_requires]
*: darwin-toolchain/1.0.8@theodelrieu/stable
```

The error was:
`ld: building for iOS, but linking in object file (CMakeFiles/test.dir/src/main.cpp.o) built for iOS Simulator, file 'CMakeFiles/test.dir/src/main.cpp.o' for architecture arm64` 

Adding `os.sdk` setting to the `tools.apple_deployment_target_flag()` function fixes it.